### PR TITLE
Fix double title output

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,6 @@
 <html lang="en" prefix="og: https://ogp.me/ns#">
   <head>
     {% include head.html %}
-    <title>{{ post.title | default: site.title }}</title>
   </head>
   <body class="container grid grid-cols-4 lg:container lg:my-4">
     {% include header.html %}


### PR DESCRIPTION
## What does this pull request do?

Fixes double output of `<title>` tag.

## Why is this pull request needed?

Built-in SEO tools already provide a `<title>` tag.
