### PR TITLE
Fix syntax error caused by dependabot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "devDependencies": {
         "esbuild": "^0.17.15",
-        "tailwindcss": "^3.3.1"
+        "tailwindcss": "^3.3.1",
         "workbox-cli": "^6.5.4",
         "workbox-precaching": "^6.5.1",
         "workbox-recipes": "^6.5.1"


### PR DESCRIPTION
## What does this pull request do?

Fix syntax error that prevents npm and Dependabot from running.

## Why is this pull request needed?

An update created by Dependabot caused a syntax error.
